### PR TITLE
Update stack resolver

### DIFF
--- a/src/DarkSky/App/Config/ArgumentParser.hs
+++ b/src/DarkSky/App/Config/ArgumentParser.hs
@@ -4,6 +4,7 @@ module DarkSky.App.Config.ArgumentParser
 
 import DarkSky.App.Config
 import DarkSky.Types (Coordinate(..), Degrees)
+import Data.Monoid
 import Options.Applicative
 
 argumentParser :: ParserInfo Config

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.11
+resolver: lts-8.21
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
The only change I noticed with updating to the latest LTS was that optparse-applicative no longer exports the `<>` operator, so I imported it from Data.Monoid.